### PR TITLE
Minor formatting fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
 <li><b><a href="http://game.bit">game.bit</a></b> - owned by danPixl - HTML5 Games</li>
 <li><b><a href="http://3ds.hax">3ds.hax</a></b> - owned by LyricLy - 3DS Hacking Guides and Tools</li>
 <li><b><a href="http://js.fans">js.fans</a></b> - owned by danPixll - Everything Javascript</li>
-<li><b><a href="http://my.hub">my.hub<a></b> - owned by Wintier - Personal site</li>
+<li><b><a href="http://my.hub">my.hub</a></b> - owned by Wintier - Personal site</li>
 <li><b><a href="http://oneshot.fans">oneshot.fans</a></b> - owned by leo60228 - OneShot fandom</li>
 
         </ul>  


### PR DESCRIPTION
One item in the All Sites section was teal coloured instead of black, due to a missing forwardslash in a closing `<a>` tag.